### PR TITLE
Create csv-to-keychain-access

### DIFF
--- a/csv-to-keychain-access
+++ b/csv-to-keychain-access
@@ -1,0 +1,47 @@
+
+-- Select the csv to import to iCloud keychain
+set theFile to (choose file with prompt "Select the CSV file")
+
+-- Read csv file
+set f to read theFile
+
+-- Split lines into records
+set recs to paragraphs of f
+
+-- getting values for each record
+set vals to {}
+set AppleScript's text item delimiters to ","
+repeat with i from 1 to length of recs
+	set end of vals to text items of (item i of recs)
+	set kcURL to text item 1 of (item i of recs)
+	set kcUsername to text item 2 of (item i of recs)
+	set kcPassword to text item 3 of (item i of recs)
+	
+	activate application "Keychain Access"
+	
+	tell application "System Events" to tell application process "Keychain Access"
+		keystroke "n" using {command down}
+		
+		-- Write fields
+		delay 0.2
+		tell application "System Events" to keystroke kcURL
+		delay 0.2
+		keystroke tab
+		tell application "System Events" to keystroke kcUsername
+		delay 0.2
+		keystroke tab
+		tell application "System Events" to keystroke kcPassword
+		
+		delay 0.2
+		keystroke tab
+		delay 0.2
+		
+		keystroke return
+		delay 0.2
+		keystroke return
+		
+		
+	end tell
+	
+	
+end repeat


### PR DESCRIPTION
For anyone reading this, this imports the passwords to your Keychain Access. From there, you can visit the website on Safari and copy and paste the password once to remember it for future ease of use.
Format of file should be csv with each line being URL,username,password without quotes. This Applescript runs through and add each code to Keychain Access. Allows for duplicate but may have some issues and stop halfway. To resolve this, run your csv file a few times till you are sure all the passwords are added. Thank you.